### PR TITLE
Remove Sepolia from networks that can be selected

### DIFF
--- a/app/context/WalletContext.tsx
+++ b/app/context/WalletContext.tsx
@@ -1,20 +1,20 @@
-import "@rainbow-me/rainbowkit/styles.css";
+import { env } from "@/env.mjs";
 import {
+  darkTheme,
   getDefaultConfig,
   RainbowKitProvider,
-  darkTheme,
 } from "@rainbow-me/rainbowkit";
-import { env } from "@/env.mjs";
-import { WagmiProvider } from "wagmi";
-import { polygonAmoy, sepolia } from "wagmi/chains";
+import "@rainbow-me/rainbowkit/styles.css";
 import React, { ReactNode } from "react";
+import { WagmiProvider } from "wagmi";
+import { polygonAmoy } from "wagmi/chains";
 
 const projectId = env.NEXT_PUBLIC_PROJECT_ID || "";
 
 const config = getDefaultConfig({
   appName: "test-app",
   projectId,
-  chains: [polygonAmoy, sepolia],
+  chains: [polygonAmoy],
   ssr: true,
 });
 


### PR DESCRIPTION
When trying TACo encryption or decryption with Sepolia network selected, it returns an error: "Error: No contract found for name: Coordinator".

If you select Sepolia, the web3 provider (Metamask) will try to call the Coordinator contract on Sepolia, but the testnet where this contract lives is Polygon Amoy, so this make the app to fail.

**Reviews: 1**

Note for reviewers:
It seems that prettier organized the imports as well.